### PR TITLE
в max-height в качестве разделителя дробного числа стоит запятая вместо точки

### DIFF
--- a/htdocs/sources/lib/post_parser.php
+++ b/htdocs/sources/lib/post_parser.php
@@ -1950,7 +1950,7 @@ class post_parser {
 				$lines_count = $ibforums->member['syntax_lines_count'] !== NULL ? $ibforums->member['syntax_lines_count'] : 10;
 				if ($lines_count != 0) {
 					$lines_count *= 1.5;
-					$style = sprintf("max-height: %1.1fem;", $lines_count);
+					$style = sprintf("max-height: %sem;", strval(round($lines_count, 1)));
 					$class .= " code_collapsed ";
 				}
 				$use_wrap = $ibforums->member['syntax_use_wrap'] !== NULL ? $ibforums->member['syntax_use_wrap'] : false;


### PR DESCRIPTION
Была привязка к локали (из-за printf). Отвязал.

http://forum.sources.ru/index.php?showtopic=163336&view=findpost&p=3256986
