### PR TITLE
Баг с "сегодня" для сообщений годовалой давности

### DIFF
--- a/htdocs/sources/functions.php
+++ b/htdocs/sources/functions.php
@@ -2620,6 +2620,8 @@ echo "-----------------<br>\n";
 				// собираем в кучу
 				$datef_date = $html[0].$hours." ".sprintf($ibforums->lang['hours_ago'], $ending.$html[1]);
 				$datef = "%date";
+			}elseif(date('Y', $date) !== date('Y')){
+				//nothing to do
 			}elseif(strftime("%j", $date) == strftime("%j")){
 				// сегодн€шн€€ дата
 				$datef_date = $html[0].$ibforums->lang['today'].$html[1];


### PR DESCRIPTION
Пофиксил появление "вчера"/"сегодня" у сообщений отправленных ровно год, 2 и более назад.

Исправил методом минимальных изменений ибо не фиг было такой говнокод заливать не глядя и не моя это забота - его исправлять.
