### PR TITLE
Подавление вывода сообщений в скрипте создания зон

### DIFF
--- a/htdocs/html/timezones.js.php
+++ b/htdocs/html/timezones.js.php
@@ -41,7 +41,8 @@ $(window).load(function() {
 });
 
 <?php
-$err = error_reporting(0);
+//turn off errors and store prev value
+$prev_ini = ini_set('display_errors', 'Off');
 
 $tzones = array();
 
@@ -59,4 +60,6 @@ if ($_GET['current']) {
 	echo ";\ncur_region = ".json_encode($region);
 	echo ";\ncur_zone = ".json_encode($zone);
 }
-error_reporting($err);
+
+//restore displaying errors
+ini_set('display_errors', $err);


### PR DESCRIPTION
Если код, создающий список временных зон генерирует хотя-бы notice, список не создаётся, а текст уведомления записывается прямо в js.
