### PR TITLE
Опция img для аттача

### DIFF
--- a/htdocs/sources/Post.php
+++ b/htdocs/sources/Post.php
@@ -1112,9 +1112,9 @@ class Post
 
 			$array = $attach->saveToDB($save_to);
 
-			if (strpos($post, "[attach=#{$i}]") !== false)
+			if (preg_match('/\[attach=#' . $i . '(,[a-z,]+)?\]/i', $post) !== 0)
 			{
-				$post = str_replace("[attach=#{$i}]", "[attach=" . $attach->attachId() . "]", $post);
+				$post = preg_replace('/\[attach=#' . $i . '(,[a-z,]+)?\]/', "[attach=" . $attach->attachId() . "$1]", $post);
 			} else
 			{
 				$attach_append .= "\n[attach={$attach->attachId()}][/attach]";

--- a/htdocs/sources/lib/classes/Attachment.class.php
+++ b/htdocs/sources/lib/classes/Attachment.class.php
@@ -21,6 +21,11 @@ if (!class_exists('Attachment'))
 
 		private $item_id;
 		private $item_type = self::ITEM_TYPE_POST;
+		/**
+		 * Additional options
+		 * @var array
+		 */
+		private $options = [];
 
 		protected $realFilename;
 
@@ -698,6 +703,22 @@ if (!class_exists('Attachment'))
 
 			return $return;
 
+		}
+
+		public function setOptions($options = [])
+		{
+			$this->options = array_fill_keys(array_map('strtolower', array_filter($options)), 1);
+
+		}
+
+		public function getOptions()
+		{
+			return array_keys($this->options);
+		}
+
+		public function hasOption($option)
+		{
+			return isset($this->options[$option]);
 		}
 	}
 

--- a/htdocs/sources/lib/classes/PostParser.class.php
+++ b/htdocs/sources/lib/classes/PostParser.class.php
@@ -780,7 +780,7 @@ class PostParser
 		 */
 		$this->attachments      = array();
 		$this->post_attachments = array();
-		$txt                    = preg_replace_callback('#\[attach\s*=\s*(p?)(\d+)?\s*\](.*?)\[/attach\]#i', array(
+		$txt                    = preg_replace_callback('#\[attach=(p?)(\d+)?(?:,([a-z,]+))?\](.*?)\[/attach\]#i', array(
 		                                                                                                          $this,
 		                                                                                                          'regex_attach'
 		                                                                                                     ), $txt);
@@ -795,10 +795,12 @@ class PostParser
 		 * $matches[0] = '[attach=00000,link]...[/attach]'
 		 * $matches[1] = { 'p' | '' }
 		 * $matches[2] = <id>
-		 * $matches[3] = <текст>
+		 * $matches[3] = options
+		 * $matches[4] = <текст>
 		 */
 
-		list(, $p, $id, $text) = $matches;
+		list(, $p, $id, $opt_string, $text) = $matches;
+		$opts = explode(',', $opt_string);
 
 		if (!trim($p))
 		{
@@ -838,6 +840,7 @@ class PostParser
 		{
 			return $text;
 		}
+		$attach->setOptions($opts);
 		$text = $this->render_attach($attach, $text);
 		return trim($text);
 	}
@@ -864,11 +867,15 @@ class PostParser
 		return $text;
 	}
 
-	private function renderPreview(Attachment $attach, $text)
+	private function renderPreview(AttachImage $attach, $text)
 	{
 		global $ibforums, $std;
 		$alt = htmlspecialchars("{$ibforums->lang['pic_attach_thumb']} {$ibforums->lang['pic_zoom_thumb']}");
-		if ($ibforums->vars['siu_width'] AND $ibforums->vars['siu_height'])
+
+		if($attach->hasOption('img'))
+		{
+			$text = "<img src='" . $attach->getHref() . "' border='0' alt='$alt'>";
+		} elseif ($ibforums->vars['siu_width'] AND $ibforums->vars['siu_height'])
 		{
 
 			if (!trim($text))


### PR DESCRIPTION
Добавлена возможность вставлять вместо превью полное приаттаченное изображение как в теге [img] указав опцию img. Если аттач не является изображением, опция не даёт эффекта

Смысл:
тег [img] не воспринимает url'ы аттачей, а доработкой его я заниматься не хочу, т.к. считаю что от него больше вреда чем пользы из-за возможности подключения внешних изображений (от удаления ссылаемых файлов и простой защиты от хотлинков до попыток собирать инфу с пользовательских браузеров посредством данных изображений).

Пример: 
[attach=#0,img][/attach]
[attach=2134,img][/attach]
