### PR TITLE
css-стили для групп пользователей

### DIFF
--- a/conf_global.sample.php
+++ b/conf_global.sample.php
@@ -430,3 +430,4 @@ $INFO['database_error_page'] = "<html><head><title>Invision Power Board Database
 $INFO['errors_text'] = 'An %TYPE% has been caught in %FILE% on line %LINE% with message
 %MESSAGE%
 ';
+$INFO['listed_groups_ids'] = '4,7,26,9,25,3';

--- a/db_schema/db/2014_04_20_05_03_05.php
+++ b/db_schema/db/2014_04_20_05_03_05.php
@@ -1,0 +1,126 @@
+<?php
+
+class Migration_2014_04_20_05_03_05 extends MpmMigration
+{
+
+	public function up(PDO &$pdo)
+	{
+		$new_classes = [
+			4  => 'group-admins',
+			2  => 'group-guests',
+			3  => 'group-members',
+			1  => 'group-validating',
+			5  => 'group-banned',
+			7  => 'group-moderators',
+			9  => 'group-project_coordinators',
+			14 => 'group-global_moderators',
+			15 => 'group-comoderators',
+			16 => 'group-offenders group-offenders-l1',
+			17 => 'group-offenders group-offenders-l2',
+			18 => 'group-offenders group-offenders-l3',
+			19 => 'group-offenders group-offenders-l4',
+			20 => 'group-offenders group-offenders-l5',
+			21 => 'group-offenders group-offenders-l6',
+			22 => 'group-offenders group-offenders-l7',
+			23 => 'group-offenders group-offenders-l8',
+			24 => 'group-offenders group-offenders-l9',
+			25 => 'group-club_members',
+			26 => 'group-veterans',
+			27 => 'group-search_bots',
+			28 => 'group-developers',
+			29 => 'group-special',
+			30 => 'group-test',
+			31 => 'group-newbies',
+			32 => 'group-super_admins',
+		];
+		$stmt        = $pdo->prepare('UPDATE ibf_groups SET prefix=:prefix, suffix=:suffix WHERE g_id = :id');
+		foreach ($new_classes as $id => $class)
+		{
+			$stmt->execute(
+				[
+					':prefix' => sprintf('<span class="%s">', $class),
+					':suffix' => '</span>',
+					':id'     => $id
+				]
+			);
+		}
+	}
+
+	public function down(PDO &$pdo)
+	{
+		$groups_from_db = [
+			4  => ['title' => "Администраторы", 'prefix' => "<span class='movedprefix'>", 'suffix' => "</span>"],
+			2  => ['title' => "Гости", 'prefix' => "", 'suffix' => ""],
+			3  => ['title' => "Участники", 'prefix' => "", 'suffix' => ""],
+			1  => ['title' => "Ожидающие доступа", 'prefix' => "", 'suffix' => ""],
+			5  => ['title' => "Бан", 'prefix' => "<span style='color:gray'>", 'suffix' => "</span>"],
+			7  => ['title' => "Модераторы", 'prefix' => "<span style='color:blue'>", 'suffix' => "</span>"],
+			9  => ['title' => "Координаторы проектов", 'prefix' => "<span class='voteprefix'>", 'suffix' => "</span>"],
+			14 => ['title' => "Супер модераторы", 'prefix' => "<span style='color:orange;'>", 'suffix' => "</span>"],
+			15 => ['title' => "Комодераторы", 'prefix' => "<span style='color:blue'>", 'suffix' => "</span>"],
+			16 => [
+				'title'  => "Нарушившие правила. Уровень 1",
+				'prefix' => "<span style='color:gray'>",
+				'suffix' => "</span>"
+			],
+			17 => [
+				'title'  => "Нарушившие правила. Уровень 2",
+				'prefix' => "<span style='color:gray'>",
+				'suffix' => "</span>"
+			],
+			18 => [
+				'title'  => "Нарушившие правила. Уровень 3",
+				'prefix' => "<span style='color:gray'>",
+				'suffix' => "</span>"
+			],
+			19 => [
+				'title'  => "Нарушившие правила. Уровень 4",
+				'prefix' => "<span style='color:gray'>",
+				'suffix' => "</span>"
+			],
+			20 => [
+				'title'  => "Нарушившие правила. Уровень 5",
+				'prefix' => "<span style='color:gray'>",
+				'suffix' => "</span>"
+			],
+			21 => [
+				'title'  => "Нарушившие правила. Уровень 6",
+				'prefix' => "<span style='color:gray'>",
+				'suffix' => "</span>"
+			],
+			22 => [
+				'title'  => "Нарушившие правила. Уровень 7",
+				'prefix' => "<span style='color:gray'>",
+				'suffix' => "</span>"
+			],
+			23 => [
+				'title'  => "Нарушившие правила. Уровень 8",
+				'prefix' => "<span style='color:gray'>",
+				'suffix' => "</span>"
+			],
+			24 => [
+				'title'  => "Нарушившие правила. Уровень 9",
+				'prefix' => "<span style='color:gray'>",
+				'suffix' => "</span>"
+			],
+			25 => [
+				'title'  => "Участники клуба Sources.Ru",
+				'prefix' => "<span style='color:navy'>",
+				'suffix' => "</span>"
+			],
+			26 => ['title' => "Ветераны", 'prefix' => "<span style='color:purple'>", 'suffix' => "</span>"],
+			27 => ['title' => "Поисковые машины", 'prefix' => "<i>", 'suffix' => "</i>"],
+			28 => ['title' => "Developers", 'prefix' => "", 'suffix' => ""],
+			29 => ['title' => "Special", 'prefix' => "", 'suffix' => ""],
+			30 => ['title' => "Test", 'prefix' => "", 'suffix' => ""],
+			31 => ['title' => "Newbie", 'prefix' => "", 'suffix' => ""],
+			32 => ['title' => "Суперадминистраторы", 'prefix' => "<span class='movedprefix'>", 'suffix' => "</span>"],
+		];
+		$stmt           = $pdo->prepare('UPDATE ibf_groups SET prefix=:prefix, suffix=:suffix WHERE g_id = :id');
+		foreach ($groups_from_db as $id => $fields)
+		{
+			$stmt->execute([':id' => $id, ':prefix' => $fields['prefix'], ':suffix' => $fields['suffix']]);
+		}
+	}
+
+}

--- a/htdocs/Skin/s1/skin_boards.php
+++ b/htdocs/Skin/s1/skin_boards.php
@@ -154,21 +154,41 @@ EOF;
 
 function ActiveUsers($active, $friends = "") {
 global $ibforums;
-//todo явно прописанные группы пользователей
+
 return <<<EOF
 	<tr class="online-summary-row">
-		<td class="pformstrip online-summary" colspan="2">$active[TOTAL] {$ibforums->lang['active_users']}</td>
+		<td class="pformstrip online-summary" colspan="2">{$active['TOTAL']} {$ibforums->lang['active_users']}</td>
   </tr>
   <tr class="online-detailed-row">
 		<td width="5%" class="row2 block-image"><{F_ACTIVE}></td>
 		<td class="row4 online-detailed" width="95%">
       <span class="guests-online-total"><b>{$active['GUESTS']}</b> {$ibforums->lang['guests']}</span>, <span class="members-online-total"><b>{$active['MEMBERS']}</b> {$ibforums->lang['public_members']} <b>{$active['ANON']}</b> {$ibforums->lang['anon_members']}</span>
       <div class="thin">{$friends}<div class="members-online">{$active['NAMES']}</div>
-      <div class="members-categories">[<a href="{$ibforums->base_url}act=Members&max_results=30&filter=4&sort_order=asc&sort_key=name&st=0"><span class="movedprefix">администраторы</span></a>,&nbsp;<a href="{$ibforums->base_url}act=Members&max_results=30&filter=7&sort_order=asc&sort_key=name&st=0"><span style="color:blue">модераторы</span></a>,&nbsp;<a href="{$ibforums->base_url}act=Members&max_results=30&filter=26&sort_order=asc&sort_key=name&st=0"><span style="color:purple">ветераны</span></a>,&nbsp;<a href="{$ibforums->base_url}act=Members&max_results=30&filter=9&sort_order=asc&sort_key=name&st=0"><span class="voteprefix">координаторы проектов</span></a>,&nbsp;<a href="{$ibforums->base_url}act=Members&max_results=30&filter=25&sort_order=asc&sort_key=name&st=0"><span style="color:navy">участники клуба</span></a>,&nbsp;<a href="{$ibforums->base_url}act=Members&max_results=30&filter=3&sort_order=asc&sort_key=name&st=0">участники</a>,&nbsp;<span style="color:gray">наказанные</span>]</div></div>
+      <div class="members-groups-list-wrapper">{$active['groups_list_html']}</div></div>
       {$active['links']}
     </td>
   </tr>
+EOF;
+}
 
+function renderMemberGroupsList($groups, $add_offenders = TRUE) {
+	$output = '<ul class="members-groups-list">';
+	foreach($groups as $group) {
+		$output .= '<li>' . $this->renderMemberGroup($group) . '</li>';
+	}
+	if($add_offenders)
+		{
+			$output .= '<li><span class="group-offenders">' . Ibf::app()->lang['group_offenders'] . '</span></li>';
+		}
+	$output .= '</ul>';
+	return $output;
+EOF;
+}
+
+function renderMemberGroup($group) {
+	$ibforums = Ibf::app();
+	return <<<EOF
+	<a href="{$ibforums->base_url}act=Members&max_results=30&filter={$group['g_id']}&sort_order=asc&sort_key=name&st=0">{$group['prefix']}{$group['g_title']}{$group['suffix']}</a>
 EOF;
 }
 

--- a/htdocs/cache/css_11.css
+++ b/htdocs/cache/css_11.css
@@ -350,3 +350,12 @@ ul.b-breadcrumbs-top li:first-child{
 
 .pm-list-row { background-color: #754c24; background-image: url('/style_images/Sources_-383/dback.gif') }
 .pm-list-row.selected { background-color: #8c6239; background-image: url('http://forum.sources.ru/style_images/Sources_-383/back.gif') }
+
+.group-super_admins,
+.group-admins {
+    color:#FFC042;
+}
+
+.group-project_coordinators {
+    color:#59EF4F;
+}

--- a/htdocs/cache/css_14.css
+++ b/htdocs/cache/css_14.css
@@ -907,6 +907,7 @@ LABEL {
 .quotemain {
 	BORDER-RIGHT: #000 1px dotted; PADDING-RIGHT: 4px; BORDER-TOP: 0px; PADDING-LEFT: 4px; BACKGROUND: #fafcfe; PADDING-BOTTOM: 4px; MARGIN: 0px auto 8px; BORDER-LEFT: #8394b2 4px solid; COLOR: #465584; PADDING-TOP: 4px; BORDER-BOTTOM: #000 1px dotted
 }
+.group-project_coordinators,
 .voteprefix {
 	COLOR: #20b2aa;
 }
@@ -1095,7 +1096,7 @@ ul.b-breadcrumbs-top li:first-child{
     padding-bottom: 5px;
 }
 .online-stats-record,
-.members-categories,
+.members-groups-list,
 .friends-title
 {
     color: #999999;
@@ -1228,4 +1229,24 @@ ul.b-breadcrumbs-top li:first-child{
 
 .post-edited-message {
     color: lightgray;
+}
+
+.group-admins {
+    color: goldenrod;
+}
+
+.group-moderators {
+    color: #00bfff;
+}
+
+.group-club_members {
+    color: #87ceeb;
+}
+
+.group-veterans {
+    color: #dda0dd;
+}
+
+.group-search_bots {
+color: lightgray;
 }

--- a/htdocs/cache/css_common.css
+++ b/htdocs/cache/css_common.css
@@ -815,3 +815,68 @@ span.b-post-links-post:before {
 .post-edited-message {
     margin-top: 1.5em;
 }
+
+.group-super_admins,
+.group-admins {
+    color: red;
+}
+
+.group-banned {
+    color: gray;
+}
+
+.group-moderators {
+    color: blue;
+}
+
+.group-project_coordinators {
+    color: green;
+}
+
+.group-global_moderators {
+    color: orange;
+}
+
+.group-comoderators {
+    color: blue;
+}
+
+.group-veterans {
+    color: purple;
+}
+
+.group-offenders {
+    color: gray;
+}
+
+.group-search_bots {
+    font-style: italic;
+}
+
+.group-club_members {
+    color: navy;
+}
+
+.members-groups-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.members-groups-list:before {
+    content: '[';
+}
+
+.members-groups-list:after {
+    content: ']';
+}
+
+.members-groups-list li {
+    display: inline;
+    padding: 0;
+    margin-right: 0.3em;
+}
+
+.members-groups-list li:not(:last-child):after {
+    content: ',';
+}

--- a/htdocs/lang/en/lang_boards.php
+++ b/htdocs/lang/en/lang_boards.php
@@ -65,4 +65,4 @@ $lang['users_online_today']  = "Visits today: <b>#ALL#</b> (<b>#USERS#</b> users
 $lang['users_online_yesterday']  = "Visits yesterday: <b>#ALL#</b> (<b>#USERS#</b> users, <b>#GUESTS#</b> guests and <b>#BOTS#</b> bots)";
 $lang['online_record']  = "Most visits for a week: <b>#ALL#</b> (<b>#USERS#</b> users, <b>#GUESTS#</b> guests and <b>#BOTS#</b> bots) was <b>#DATE#</b>";
 $lang['your_friends']  = "<b>Friends of mine</b>:";
-
+$lang['group_offenders'] = "Offenders";

--- a/htdocs/lang/ru/lang_boards.php
+++ b/htdocs/lang/ru/lang_boards.php
@@ -65,4 +65,4 @@ $lang['users_online_yesterday']  = "Посещений вчера: <b>#ALL#</b> 
 $lang['online_record']  = "Общий рекорд посещений за сутки: <b>#ALL#</b> (<b>#USERS#</b> участников, <b>#GUESTS#</b> гостей и <b>#BOTS#</b> поисковых машин) зафиксирован <b>#DATE#</b>";
 $lang['category_record']  = "Рекорд посещений за сутки по категориям: <b>#USERS#</b> участников, <b>#GUESTS#</b> гостей и <b>#BOTS#</b> поисковых машин";
 $lang['your_friends']  = "<b>Мои друзья</b>:";
-
+$lang['group_offenders'] = 'наказанные';

--- a/htdocs/sources/Boards.php
+++ b/htdocs/sources/Boards.php
@@ -373,7 +373,7 @@ class Boards {
 				$friends = ( $active['FRIENDS'] )
 					? $this->html->ActiveFriends($active)
 					: "";
-
+				$active['groups_list_html'] = $this->renderMemberGroups();
 				$stats_html .= $this->html->ActiveUsers($active, $friends);
 
 
@@ -1532,6 +1532,26 @@ class Boards {
 		}
 
 		return $forum_data;
+	}
+
+	protected function renderMemberGroups() {
+
+		$listed_groups_ids = (array)explode(',', Ibf::app()->vars['listed_groups_ids']);
+		$visible_groups = array_fill_keys($listed_groups_ids, '');
+
+		$stmt = Ibf::app()->db
+			->prepare('SELECT g_id, g_title, prefix, suffix FROM ibf_groups WHERE g_id IN(' . IBPDO::placeholders($listed_groups_ids) . ')')
+			->execute($listed_groups_ids);
+
+		if ($stmt->rowCount() == 0) {
+			return '';
+		}
+
+		while ($row = $stmt->fetch()) {
+			$visible_groups[$row['g_id']] = $row;
+		}
+		return $this->html->renderMemberGroupsList($visible_groups);
+
 	}
 	/* End */
 }


### PR DESCRIPTION
1. Замена захаркоденых стилей для ников пользователей классами
2. Замена захардкоденого списка групп в статистике динамической генерацией на основе настроек.

!!! Требуется принять миграцию
!!! Требуется скопировать новую строку из conf_global.sample.php в conf_global.php

зы: 
Знаю, что первый пункт можно сделать банально через админку, но т.к. наша доблестная администрация уже ровно месяц доблестно меняет 4 символа в заголовке... в общем, не будем их отвлекать лишний раз.
