### PR TITLE
Фикс лишних пробелов в подсветке синтаксиса

### DIFF
--- a/htdocs/Skin/s1/skin_global.php
+++ b/htdocs/Skin/s1/skin_global.php
@@ -745,27 +745,27 @@ EOF;
 function renderTagMM($text){
 	$title = Ibf::app()->lang['mod_mes'];
 	return <<<EOF
-		<div class="tag-mm"><div class="tag-mm-header">{$title}</div><div class="tag-mm-body">{$text}</div></div>
+<div class="tag-mm"><div class="tag-mm-header">{$title}</div><div class="tag-mm-body">{$text}</div></div>
 EOF;
 }
 
 function renderTagGM($text) {
 	$title = Ibf::app()->lang['glob_mod_mes'];
 	return <<<EOF
-		<div class="tag-gm"><div class='tag-gm-header'>{$title}</div><div class='tag-gm-body'>{$text}</div></div>
+<div class="tag-gm"><div class='tag-gm-header'>{$title}</div><div class='tag-gm-body'>{$text}</div></div>
 EOF;
 
 }
 
 function renderTagListUnordered($text){
 	return <<<EOF
-	<ul class="tag-list">{$text}</ul>
+<ul class="tag-list">{$text}</ul>
 EOF;
 }
 
 function renderTagListOrdered($text, $type){
 return <<<EOF
-	<ol class="tag-list" type="{$type}">{$text}</ol>
+<ol class="tag-list" type="{$type}">{$text}</ol>
 EOF;
 }
 
@@ -789,19 +789,19 @@ EOF;
 
 function renderTagColor($value, $text) {
 	return <<<EOF
-	<span class="tag-color" data-value="{$value}" style="color: #{$value}">{$text}</span>
+<span class="tag-color" data-value="{$value}" style="color: #{$value}">{$text}</span>
 EOF;
 }
 
 function renderTagColorNamed($value, $text) {
 	return <<<EOF
-	<span class="tag-color tag-color-named" data-value="{$value}" style="color: {$value}">{$text}</span>
+<span class="tag-color tag-color-named" data-value="{$value}" style="color: {$value}">{$text}</span>
 EOF;
 }
 
 function renderTagFont($value, $text) {
 	return <<<EOF
-    <span class="tag-font" data-value="{$value}" style="font-family:{$value}">{$text}</span>
+<span class="tag-font" data-value="{$value}" style="font-family:{$value}">{$text}</span>
 EOF;
 }
 }


### PR DESCRIPTION
На самом деле не только там, но это уже малозаметные мелочи.

Это фиксит серверную подсветку. Клиентскую можно обновить сохранив любое правило или порядок правил в ней. Ну или как-то вызывать Moderate::save_syntax_to_js() с id подсветки
