### PR TITLE
Издеваемся над урлами, сезон 3, эпизод 12

### DIFF
--- a/conf_global.sample.php
+++ b/conf_global.sample.php
@@ -431,3 +431,7 @@ $INFO['errors_text'] = 'An %TYPE% has been caught in %FILE% on line %LINE% with 
 %MESSAGE%
 ';
 $INFO['listed_groups_ids'] = '4,7,26,9,25,3';
+
+$INFO['url_parser_search_title_metatags'] = '';//meta tag names split by ','
+$INFO['url_parser_search_page_title'] = '';//boolean
+$INFO['url_parser_search_page_title_till'] = 4096;//bytes to read from url. Prevents loading large (and useless) amount of data, however some pages have js in their headers before the title tag


### PR DESCRIPTION
- Убрал обработку урлов с рендера постов. Для старых постов спец. обработки нет и не будет. Если сильно хочется - пересохраните пост.
- Расширил поиск урлов в посте при сохранении - теперь ссылки оборачиваются в [url] и потом никому не мешают (надеюсь). Использована оригинальная регулярка, только с флагом unicode
- Во время оборачивания в тег возможно сканирование страницы на предмет именованных метатегов или тега title с подстановкой их содержимого внутрь тега [url]. Процедура заметно тормозит сохранение поста (особенно на мёртвых урлах), так что изначально выключена.

В conf_global добавлены следующие переменные:
- `url_parser_search_title_metatags` - список имён метатегов для поиска через запятую
- `url_parser_search_page_title` - искать тег title или нет (значение приводится к boolean)
- `url_parser_search_page_title_till` - макс. количество байт для чтения. Защита от скачивания больших объёмов данных. Не имеет смысла если `url_parser_search_page_title` выключен

Поиск осуществляется сначала по метатегам, потом по title. Подставляется первое попавшееся значение. Если ничего не найдено подставляется сам урл.
**Attention**: при включении обоих вариантов на каждый урл делается 2 запроса. Пока так. Полноценно парсить html как-то не захотелось.

Необходимо потестировать в первую очередь на урлах с необычными символами (пробелы точно работать не будут)
