### PR TITLE
Mysql error при потере результатов поиска

### DIFF
--- a/htdocs/sources/Select.php
+++ b/htdocs/sources/Select.php
@@ -1271,16 +1271,27 @@ class Search
 
 		if (!$this->unique_id)
 		{
-			$ibforums->functions->Error(array(
-			                 'LEVEL' => 1,
-			                 'MSG'   => 'no_search_results'
-			            ));
+			$ibforums->functions->Error(
+				[
+					'LEVEL' => 1,
+					'MSG'   => 'no_search_results'
+				]
+			);
 		}
 
 		$stmt = $ibforums->db
 			->prepare("SELECT * FROM ibf_search_results WHERE id=:id")
 			->bindParam(':id', $this->unique_id)
 			->execute();
+		if($stmt->rowCount() === 0)
+		{
+			$ibforums->functions->Error(
+				[
+					'LEVEL' => 1,
+					'MSG'   => 'no_search_results'
+				]
+			);
+		}
 		$sr   = $stmt->fetch();
 
 		$this->sort_order = $sr['sort_order'];


### PR DESCRIPTION
Если во время поиска его результаты были потеряны (изменили searchid или данные уже отвалились по времени), то вылетает ошибка

```
Fatal error: Uncaught exception 'PDOException' with message 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'LIMIT 0,25' 
```

Исправлено на вывод сообщения "ничего не найдено"
