### PR TITLE
Спец. обработка символа `)` на конце урлов.

### DIFF
--- a/htdocs/sources/lib/classes/PostParser.class.php
+++ b/htdocs/sources/lib/classes/PostParser.class.php
@@ -3090,6 +3090,12 @@ class PostParser
 			$url['show'] = preg_replace("/([\.,\?]|&#33;)$/", "", $url['show']);
 		}
 
+		//Let's think there are not so many links with ')' but without '(' in the internet
+		if(substr($url['html'], -1) == ')' && strpos($url['html'], '(') === false ) {
+			$url['end'] = ')' . $url['end'];
+			$url['html'] = substr($url['html'], 0, -1);
+		}
+
 		// Make sure it's not being used in a closing code/quote block
 
 		if (preg_match("/\[\/(quote|code)/i", $url['html']))


### PR DESCRIPTION
Обработка основана на том, что урлы с символом `)`, но без символа `(` встречаются крайне редко, и в подобных случаях закрывающая скобка, скорее всего находится вне урла.

Это коснётся только самого последнего символа урла, строки вроде `http://blah.blah/)))))))))test` распарсятся как урл полностью в любом случае
