### PR TITLE
Возможность передачи параметров процессорам из конфига

### DIFF
--- a/app/config/logs.sample.php
+++ b/app/config/logs.sample.php
@@ -13,7 +13,16 @@ return [
     'channels'      => [
         '*'   => [
             'processors' => [
-                '\Monolog\Processor\IntrospectionProcessor',
+                [
+                    'class'   => '\Monolog\Processor\IntrospectionProcessor',
+                    'options' => [
+                        'skipClassesPartials' => [
+                            'Monolog\\',
+                            'Logs',
+                            'PDO',
+                        ]
+                    ],
+                ],
             ],
         ],
         'PHP' => [

--- a/docs/monolog_support.md
+++ b/docs/monolog_support.md
@@ -27,7 +27,20 @@ return [
     'channels'      => [
         '*'   => [
             'processors' => [ //Перечень процессоров для подключения к каналу
-                              '\Monolog\Processor\IntrospectionProcessor',
+                //Используется либо полное наименование класса
+                '\Logs\Processor\MemberProcessor',
+                //либо массив из имени класса и его параметров.
+                 [
+                    'class' => '\Monolog\Processor\IntrospectionProcessor',
+                    //Формат и содержимое options аналогичен одноименному значению из обработчиков (см. ниже)
+                    'options' => [
+                        'skipClassesPartials' => [
+                            'Monolog\\',
+                            'Logs',
+                            'PDO',
+                        ]
+                    ]
+                 ]
             ],
         ],
         'PHP' => [


### PR DESCRIPTION
Скорее всего последнее изменение, которое надо было сделать ещё до отправки монолога на devel.

Классов не добавляется, править ничего особо не надо, но хотелось-бы, чтобы настройки IntrospectionProcessor выглядели в дальнейшем так:

``` PHP
                [
                    'class'   => '\Monolog\Processor\IntrospectionProcessor',
                    'options' => [
                        'skipClassesPartials' => [
                            'Monolog\\',
                            'Logs',
                            'PDO',
                        ]
                    ],
                ],
```

Чтобы в логи писались места обращений к Logs и классам работы с бд, а не их внутренности. 

Для наглядности я изменил logs.sample.php, чтобы было понятнее.
