### PR TITLE
фикс записи в цепочку несуществующих ключей конфига

### DIFF
--- a/app/classes/Config/Registry.php
+++ b/app/classes/Config/Registry.php
@@ -203,7 +203,7 @@ class Registry
                 $ptr[$key] = $value;
                 break;
             } else {
-                if (!is_array($ptr[$key])) { //nothing to or isn't an array
+                if (!isset($ptr[$key]) || !is_array($ptr[$key])) { //nothing to or isn't an array
                     $ptr[$key] = [];
                 }
                 $ptr = & $ptr[$key];


### PR DESCRIPTION
т.е. вызов Config::set('blah1.blah2.blah3', 'some') выдаёт ошибку при отсутствии blah2
