### PR TITLE
Fixed old DB engine refactor error

### DIFF
--- a/app/classes/functions.php
+++ b/app/classes/functions.php
@@ -820,15 +820,10 @@ class functions
 		// current month
 		$cur_mon = $this->current_month();
 
-		try
-		{
-			$ibforums->db->exec("INSERT
-				INTO " . $table . "
-				VALUES ('" . $session_id . "','" . $ip_address . "'," . $cur_day . "," . $cur_mon . ")");
-		} catch (PDOException $e)
-		{
-			$this->inc_user_count($field, $cur_day, $cur_mon);
-		}
+		$ibforums->db->exec("INSERT
+			INTO " . $table . "
+			VALUES ('" . $session_id . "','" . $ip_address . "'," . $cur_day . "," . $cur_mon . ")");
+		$this->inc_user_count($field, $cur_day, $cur_mon);
 	}
 
 	/**


### PR DESCRIPTION
Почему-то старое !$DB->error было воспринято как проверка на наличие ошибки, а не отсутствие.