### PR TITLE
Fixed old DB engine refactor error

### DIFF
--- a/app/classes/functions.php
+++ b/app/classes/functions.php
@@ -825,9 +825,10 @@ class functions
 			$ibforums->db->exec("INSERT
 				INTO " . $table . "
 				VALUES ('" . $session_id . "','" . $ip_address . "'," . $cur_day . "," . $cur_mon . ")");
+			$this->inc_user_count($field, $cur_day, $cur_mon);
 		} catch (PDOException $e)
 		{
-			$this->inc_user_count($field, $cur_day, $cur_mon);
+			//finally
 		}
 	}
 


### PR DESCRIPTION
Почему-то старое !$DB->error было воспринято как проверка на наличие ошибки, а не отсутствие.