### PR TITLE
Disable log_errors in php.ini

### DIFF
--- a/docker/php/conf.d/php.ini
+++ b/docker/php/conf.d/php.ini
@@ -57,7 +57,7 @@ display_errors = Off
 ; Development Value: On
 ; Production Value: On
 ; http://php.net/log-errors
-log_errors = On
+log_errors = Off
 
 ; This directive informs PHP of which errors, warnings and notices you would like
 ; it to take action for. The recommended way of setting values for this


### PR DESCRIPTION
На проде очень много варнингов и нотисов, диск мучается жёстко. Один запрос +50 ошибок. Временно отключаем, чтоб работало нормально и диск не забило этими логами.

Требуется их все поправить, а потом можно обратно логгирование включить