### PR TITLE
Add docker ignore for static (mounted) files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+htdocs/uploads/
+docker/mysql/shared/


### PR DESCRIPTION
Убираем директории uploads и shared в dockerignore, чтоб при сборке образа вся статика и БД не монтировалась внутрь.